### PR TITLE
Fixed grammar mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ now it works on http://localhost:8080/
 
 # known issues
 
-When You are out of RAM you lose webgl context, you may get black screen when it happens, than the page will stop working, and it will require reload, if your RAM usage is still high, You may be unable to view page. If Your source map wont be higher than 4096 px, it should work fine
+When You are out of RAM you lose webgl context, you may get black screen when it happens, then the page will stop working, and it will require reload, if your RAM usage is still high, You may be unable to view page. If Your source map wont be higher than 4096 px, it should work fine


### PR DESCRIPTION
than is used to compare thing while then means at that time